### PR TITLE
Expose Convolution Api

### DIFF
--- a/src/ImageSharp/Processing/Extensions/Convolution/BoxBlurExtensions.cs
+++ b/src/ImageSharp/Processing/Extensions/Convolution/BoxBlurExtensions.cs
@@ -55,9 +55,11 @@ public static class BoxBlurExtensions
     /// The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in Y direction.
     /// </param>
     /// <returns>The <see cref="IImageProcessingContext"/>.</returns>
-    public static IImageProcessingContext BoxBlur(this IImageProcessingContext source, int radius, Rectangle rectangle, BorderWrappingMode borderWrapModeX, BorderWrappingMode borderWrapModeY)
-    {
-        var processor = new BoxBlurProcessor(radius, borderWrapModeX, borderWrapModeY);
-        return source.ApplyProcessor(processor, rectangle);
-    }
+    public static IImageProcessingContext BoxBlur(
+        this IImageProcessingContext source,
+        int radius,
+        Rectangle rectangle,
+        BorderWrappingMode borderWrapModeX,
+        BorderWrappingMode borderWrapModeY)
+        => source.ApplyProcessor(new BoxBlurProcessor(radius, borderWrapModeX, borderWrapModeY), rectangle);
 }

--- a/src/ImageSharp/Processing/Extensions/Convolution/ConvolutionExtensions.cs
+++ b/src/ImageSharp/Processing/Extensions/Convolution/ConvolutionExtensions.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.Processing.Processors.Convolution;
+
+namespace SixLabors.ImageSharp.Processing.Extensions.Convolution;
+
+/// <summary>
+/// Defines general convolution extensions to apply on an <see cref="Image"/>
+/// using Mutate/Clone.
+/// </summary>
+public static class ConvolutionExtensions
+{
+    /// <summary>
+    /// Applies a convolution filter to the image.
+    /// </summary>
+    /// <param name="source">The current image processing context.</param>
+    /// <param name="kernelXY">The convolution kernel to apply.</param>
+    /// <returns>The <see cref="IImageProcessingContext"/>.</returns>
+    public static IImageProcessingContext Convolve(this IImageProcessingContext source, DenseMatrix<float> kernelXY)
+        => Convolve(source, kernelXY, false);
+
+    /// <summary>
+    /// Applies a convolution filter to the image.
+    /// </summary>
+    /// <param name="source">The current image processing context.</param>
+    /// <param name="kernelXY">The convolution kernel to apply.</param>
+    /// <param name="preserveAlpha">Whether the convolution filter is applied to alpha as well as the color channels.</param>
+    /// <returns>The <see cref="IImageProcessingContext"/>.</returns>
+    public static IImageProcessingContext Convolve(this IImageProcessingContext source, DenseMatrix<float> kernelXY, bool preserveAlpha)
+        => Convolve(source, kernelXY, preserveAlpha, BorderWrappingMode.Repeat, BorderWrappingMode.Repeat);
+
+    /// <summary>
+    /// Applies a convolution filter to the image.
+    /// </summary>
+    /// <param name="source">The current image processing context.</param>
+    /// <param name="kernelXY">The convolution kernel to apply.</param>
+    /// <param name="preserveAlpha">Whether the convolution filter is applied to alpha as well as the color channels.</param>
+    /// <param name="borderWrapModeX">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in X direction.</param>
+    /// <param name="borderWrapModeY">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in Y direction.</param>
+    /// <returns>The <see cref="IImageProcessingContext"/>.</returns>
+    public static IImageProcessingContext Convolve(
+        this IImageProcessingContext source,
+        DenseMatrix<float> kernelXY,
+        bool preserveAlpha,
+        BorderWrappingMode borderWrapModeX,
+        BorderWrappingMode borderWrapModeY)
+        => source.ApplyProcessor(new ConvolutionProcessor(kernelXY, preserveAlpha, borderWrapModeX, borderWrapModeY));
+
+    /// <summary>
+    /// Applies a convolution filter to the image.
+    /// </summary>
+    /// <param name="source">The current image processing context.</param>
+    /// <param name="rectangle">The rectangle structure that specifies the portion of the image object to alter.</param>
+    /// <param name="kernelXY">The convolution kernel to apply.</param>
+    /// <returns>The <see cref="IImageProcessingContext"/>.</returns>
+    public static IImageProcessingContext Convolve(this IImageProcessingContext source, Rectangle rectangle, DenseMatrix<float> kernelXY)
+        => Convolve(source, rectangle, kernelXY, false);
+
+    /// <summary>
+    /// Applies a convolution filter to the image.
+    /// </summary>
+    /// <param name="source">The current image processing context.</param>
+    /// <param name="rectangle">The rectangle structure that specifies the portion of the image object to alter.</param>
+    /// <param name="kernelXY">The convolution kernel to apply.</param>
+    /// <param name="preserveAlpha">Whether the convolution filter is applied to alpha as well as the color channels.</param>
+    /// <returns>The <see cref="IImageProcessingContext"/>.</returns>
+    public static IImageProcessingContext Convolve(this IImageProcessingContext source, Rectangle rectangle, DenseMatrix<float> kernelXY, bool preserveAlpha)
+        => Convolve(source, rectangle, kernelXY, preserveAlpha, BorderWrappingMode.Repeat, BorderWrappingMode.Repeat);
+
+    /// <summary>
+    /// Applies a convolution filter to the image.
+    /// </summary>
+    /// <param name="source">The current image processing context.</param>
+    /// <param name="rectangle">The rectangle structure that specifies the portion of the image object to alter.</param>
+    /// <param name="kernelXY">The convolution kernel to apply.</param>
+    /// <param name="preserveAlpha">Whether the convolution filter is applied to alpha as well as the color channels.</param>
+    /// <param name="borderWrapModeX">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in X direction.</param>
+    /// <param name="borderWrapModeY">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in Y direction.</param>
+    /// <returns>The <see cref="IImageProcessingContext"/>.</returns>
+    public static IImageProcessingContext Convolve(
+        this IImageProcessingContext source,
+        Rectangle rectangle,
+        DenseMatrix<float> kernelXY,
+        bool preserveAlpha,
+        BorderWrappingMode borderWrapModeX,
+        BorderWrappingMode borderWrapModeY)
+        => source.ApplyProcessor(new ConvolutionProcessor(kernelXY, preserveAlpha, borderWrapModeX, borderWrapModeY), rectangle);
+}

--- a/src/ImageSharp/Processing/Extensions/Convolution/GaussianBlurExtensions.cs
+++ b/src/ImageSharp/Processing/Extensions/Convolution/GaussianBlurExtensions.cs
@@ -57,7 +57,7 @@ public static class GaussianBlurExtensions
     /// <returns>The <see cref="IImageProcessingContext"/>.</returns>
     public static IImageProcessingContext GaussianBlur(this IImageProcessingContext source, float sigma, Rectangle rectangle, BorderWrappingMode borderWrapModeX, BorderWrappingMode borderWrapModeY)
     {
-        var processor = new GaussianBlurProcessor(sigma, borderWrapModeX, borderWrapModeY);
+        GaussianBlurProcessor processor = new(sigma, borderWrapModeX, borderWrapModeY);
         return source.ApplyProcessor(processor, rectangle);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2DProcessor{TPixel}.cs
@@ -62,14 +62,14 @@ internal class Convolution2DProcessor<TPixel> : ImageProcessor<TPixel>
 
         source.CopyTo(targetPixels);
 
-        var interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
+        Rectangle interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
 
-        using (var map = new KernelSamplingMap(allocator))
+        using (KernelSamplingMap map = new(allocator))
         {
             // Since the kernel sizes are identical we can use a single map.
             map.BuildSamplingOffsetMap(this.KernelY, interest);
 
-            var operation = new Convolution2DRowOperation<TPixel>(
+            Convolution2DRowOperation<TPixel> operation = new(
                 interest,
                 targetPixels,
                 source.PixelBuffer,

--- a/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/Convolution2PassProcessor{TPixel}.cs
@@ -35,18 +35,48 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
         Rectangle sourceRectangle,
         BorderWrappingMode borderWrapModeX,
         BorderWrappingMode borderWrapModeY)
+        : this(configuration, kernel, kernel, preserveAlpha, source, sourceRectangle, borderWrapModeX, borderWrapModeY)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Convolution2PassProcessor{TPixel}"/> class.
+    /// </summary>
+    /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
+    /// <param name="kernelX">The 1D convolution kernel. X Direction</param>
+    /// <param name="kernelY">The 1D convolution kernel. Y Direction</param>
+    /// <param name="preserveAlpha">Whether the convolution filter is applied to alpha as well as the color channels.</param>
+    /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
+    /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
+    /// <param name="borderWrapModeX">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in X direction.</param>
+    /// <param name="borderWrapModeY">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in Y direction.</param>
+    public Convolution2PassProcessor(
+        Configuration configuration,
+        float[] kernelX,
+        float[] kernelY,
+        bool preserveAlpha,
+        Image<TPixel> source,
+        Rectangle sourceRectangle,
+        BorderWrappingMode borderWrapModeX,
+        BorderWrappingMode borderWrapModeY)
         : base(configuration, source, sourceRectangle)
     {
-        this.Kernel = kernel;
+        this.KernelX = kernelX;
+        this.KernelY = kernelY;
         this.PreserveAlpha = preserveAlpha;
         this.BorderWrapModeX = borderWrapModeX;
         this.BorderWrapModeY = borderWrapModeY;
     }
 
     /// <summary>
-    /// Gets the convolution kernel.
+    /// Gets the convolution kernel. X direction.
     /// </summary>
-    public float[] Kernel { get; }
+    public float[] KernelX { get; }
+
+    /// <summary>
+    /// Gets the convolution kernel. Y direction.
+    /// </summary>
+    public float[] KernelY { get; }
 
     /// <summary>
     /// Gets a value indicating whether the convolution filter is applied to alpha as well as the color channels.
@@ -68,21 +98,21 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
     {
         using Buffer2D<TPixel> firstPassPixels = this.Configuration.MemoryAllocator.Allocate2D<TPixel>(source.Size);
 
-        var interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
+        Rectangle interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
 
         // We can create a single sampling map with the size as if we were using the non separated 2D kernel
         // the two 1D kernels represent, and reuse it across both convolution steps, like in the bokeh blur.
-        using var mapXY = new KernelSamplingMap(this.Configuration.MemoryAllocator);
+        using KernelSamplingMap mapXY = new(this.Configuration.MemoryAllocator);
 
-        mapXY.BuildSamplingOffsetMap(this.Kernel.Length, this.Kernel.Length, interest, this.BorderWrapModeX, this.BorderWrapModeY);
+        mapXY.BuildSamplingOffsetMap(this.KernelX.Length, this.KernelX.Length, interest, this.BorderWrapModeX, this.BorderWrapModeY);
 
         // Horizontal convolution
-        var horizontalOperation = new HorizontalConvolutionRowOperation(
+        HorizontalConvolutionRowOperation horizontalOperation = new(
             interest,
             firstPassPixels,
             source.PixelBuffer,
             mapXY,
-            this.Kernel,
+            this.KernelX,
             this.Configuration,
             this.PreserveAlpha);
 
@@ -92,12 +122,12 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
             in horizontalOperation);
 
         // Vertical convolution
-        var verticalOperation = new VerticalConvolutionRowOperation(
+        VerticalConvolutionRowOperation verticalOperation = new(
             interest,
             source.PixelBuffer,
             firstPassPixels,
             mapXY,
-            this.Kernel,
+            this.KernelY,
             this.Configuration,
             this.PreserveAlpha);
 
@@ -140,7 +170,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
         }
 
         /// <inheritdoc/>
-        [MethodImpl(InliningOptions.ShortMethod)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetRequiredBufferLength(Rectangle bounds)
             => 2 * bounds.Width;
 
@@ -306,7 +336,7 @@ internal class Convolution2PassProcessor<TPixel> : ImageProcessor<TPixel>
         }
 
         /// <inheritdoc/>
-        [MethodImpl(InliningOptions.ShortMethod)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int GetRequiredBufferLength(Rectangle bounds)
             => 2 * bounds.Width;
 

--- a/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/ConvolutionProcessor.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.PixelFormats;
+
+namespace SixLabors.ImageSharp.Processing.Processors.Convolution;
+
+/// <summary>
+/// Defines a processor that uses a 2 dimensional matrix to perform convolution against an image.
+/// </summary>
+public class ConvolutionProcessor : IImageProcessor
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConvolutionProcessor"/> class.
+    /// </summary>
+    /// <param name="kernelXY">The 2d gradient operator.</param>
+    /// <param name="preserveAlpha">Whether the convolution filter is applied to alpha as well as the color channels.</param>
+    /// <param name="borderWrapModeX">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in X direction.</param>
+    /// <param name="borderWrapModeY">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in Y direction.</param>
+    public ConvolutionProcessor(
+        in DenseMatrix<float> kernelXY,
+        bool preserveAlpha,
+        BorderWrappingMode borderWrapModeX,
+        BorderWrappingMode borderWrapModeY)
+    {
+        this.KernelXY = kernelXY;
+        this.PreserveAlpha = preserveAlpha;
+        this.BorderWrapModeX = borderWrapModeX;
+        this.BorderWrapModeY = borderWrapModeY;
+    }
+
+    /// <summary>
+    /// Gets the 2d convolution kernel.
+    /// </summary>
+    public DenseMatrix<float> KernelXY { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the convolution filter is applied to alpha as well as the color channels.
+    /// </summary>
+    public bool PreserveAlpha { get; }
+
+    /// <summary>
+    /// Gets the <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in X direction.
+    /// </summary>
+    public BorderWrappingMode BorderWrapModeX { get; }
+
+    /// <summary>
+    /// Gets the <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in Y direction.
+    /// </summary>
+    public BorderWrappingMode BorderWrapModeY { get; }
+
+    /// <inheritdoc/>
+    public IImageProcessor<TPixel> CreatePixelSpecificProcessor<TPixel>(Configuration configuration, Image<TPixel> source, Rectangle sourceRectangle)
+        where TPixel : unmanaged,
+        IPixel<TPixel>
+    {
+        if (this.KernelXY.TryGetLinearlySeparableComponents(out float[]? kernelX, out float[]? kernelY))
+        {
+            return new Convolution2PassProcessor<TPixel>(
+                configuration,
+                kernelX,
+                kernelY,
+                this.PreserveAlpha,
+                source,
+                sourceRectangle,
+                this.BorderWrapModeX,
+                this.BorderWrapModeY);
+        }
+
+        return new ConvolutionProcessor<TPixel>(
+            configuration,
+            this.KernelXY,
+            this.PreserveAlpha,
+            source,
+            sourceRectangle,
+            this.BorderWrapModeX,
+            this.BorderWrapModeY);
+    }
+}

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorCompassProcessor{TPixel}.cs
@@ -58,12 +58,12 @@ internal class EdgeDetectorCompassProcessor<TPixel> : ImageProcessor<TPixel>
     /// <inheritdoc />
     protected override void OnFrameApply(ImageFrame<TPixel> source)
     {
-        var interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
+        Rectangle interest = Rectangle.Intersect(this.SourceRectangle, source.Bounds());
 
         // We need a clean copy for each pass to start from
         using ImageFrame<TPixel> cleanCopy = source.Clone();
 
-        using (var processor = new ConvolutionProcessor<TPixel>(this.Configuration, in this.kernels[0], true, this.Source, interest))
+        using (ConvolutionProcessor<TPixel> processor = new(this.Configuration, in this.kernels[0], true, this.Source, interest))
         {
             processor.Apply(source);
         }
@@ -78,12 +78,12 @@ internal class EdgeDetectorCompassProcessor<TPixel> : ImageProcessor<TPixel>
         {
             using ImageFrame<TPixel> pass = cleanCopy.Clone();
 
-            using (var processor = new ConvolutionProcessor<TPixel>(this.Configuration, in this.kernels[i], true, this.Source, interest))
+            using (ConvolutionProcessor<TPixel> processor = new(this.Configuration, in this.kernels[i], true, this.Source, interest))
             {
                 processor.Apply(pass);
             }
 
-            var operation = new RowOperation(source.PixelBuffer, pass.PixelBuffer, interest);
+            RowOperation operation = new(source.PixelBuffer, pass.PixelBuffer, interest);
             ParallelRowIterator.IterateRows(
                 this.Configuration,
                 interest,

--- a/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/EdgeDetectorProcessor{TPixel}.cs
@@ -53,7 +53,7 @@ internal class EdgeDetectorProcessor<TPixel> : ImageProcessor<TPixel>
     /// <inheritdoc/>
     protected override void OnFrameApply(ImageFrame<TPixel> source)
     {
-        using var processor = new ConvolutionProcessor<TPixel>(this.Configuration, in this.kernelXY, true, this.Source, this.SourceRectangle);
+        using ConvolutionProcessor<TPixel> processor = new(this.Configuration, in this.kernelXY, true, this.Source, this.SourceRectangle);
         processor.Apply(source);
     }
 }

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianBlurProcessor{TPixel}.cs
@@ -19,24 +19,6 @@ internal class GaussianBlurProcessor<TPixel> : ImageProcessor<TPixel>
     /// <param name="definition">The <see cref="GaussianBlurProcessor"/> defining the processor parameters.</param>
     /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
     /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-    public GaussianBlurProcessor(
-        Configuration configuration,
-        GaussianBlurProcessor definition,
-        Image<TPixel> source,
-        Rectangle sourceRectangle)
-        : base(configuration, source, sourceRectangle)
-    {
-        int kernelSize = (definition.Radius * 2) + 1;
-        this.Kernel = ConvolutionProcessorHelpers.CreateGaussianBlurKernel(kernelSize, definition.Sigma);
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GaussianBlurProcessor{TPixel}"/> class.
-    /// </summary>
-    /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
-    /// <param name="definition">The <see cref="GaussianBlurProcessor"/> defining the processor parameters.</param>
-    /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
-    /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
     /// <param name="borderWrapModeX">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in X direction.</param>
     /// <param name="borderWrapModeY">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in Y direction.</param>
     public GaussianBlurProcessor(
@@ -72,7 +54,7 @@ internal class GaussianBlurProcessor<TPixel> : ImageProcessor<TPixel>
     /// <inheritdoc/>
     protected override void OnFrameApply(ImageFrame<TPixel> source)
     {
-        using var processor = new Convolution2PassProcessor<TPixel>(this.Configuration, this.Kernel, false, this.Source, this.SourceRectangle, this.BorderWrapModeX, this.BorderWrapModeY);
+        using Convolution2PassProcessor<TPixel> processor = new(this.Configuration, this.Kernel, false, this.Source, this.SourceRectangle, this.BorderWrapModeX, this.BorderWrapModeY);
 
         processor.Apply(source);
     }

--- a/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor{TPixel}.cs
+++ b/src/ImageSharp/Processing/Processors/Convolution/GaussianSharpenProcessor{TPixel}.cs
@@ -19,22 +19,6 @@ internal class GaussianSharpenProcessor<TPixel> : ImageProcessor<TPixel>
     /// <param name="definition">The <see cref="GaussianSharpenProcessor"/> defining the processor parameters.</param>
     /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
     /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
-    public GaussianSharpenProcessor(
-        Configuration configuration,
-        GaussianSharpenProcessor definition,
-        Image<TPixel> source,
-        Rectangle sourceRectangle)
-        : this(configuration, definition, source, sourceRectangle, BorderWrappingMode.Repeat, BorderWrappingMode.Repeat)
-    {
-    }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="GaussianSharpenProcessor{TPixel}"/> class.
-    /// </summary>
-    /// <param name="configuration">The configuration which allows altering default behaviour or extending the library.</param>
-    /// <param name="definition">The <see cref="GaussianSharpenProcessor"/> defining the processor parameters.</param>
-    /// <param name="source">The source <see cref="Image{TPixel}"/> for the current processor instance.</param>
-    /// <param name="sourceRectangle">The source area to process for the current processor instance.</param>
     /// <param name="borderWrapModeX">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in X direction.</param>
     /// <param name="borderWrapModeY">The <see cref="BorderWrappingMode"/> to use when mapping the pixels outside of the border, in Y direction.</param>
     public GaussianSharpenProcessor(
@@ -70,7 +54,7 @@ internal class GaussianSharpenProcessor<TPixel> : ImageProcessor<TPixel>
     /// <inheritdoc/>
     protected override void OnFrameApply(ImageFrame<TPixel> source)
     {
-        using var processor = new Convolution2PassProcessor<TPixel>(this.Configuration, this.Kernel, false, this.Source, this.SourceRectangle, this.BorderWrapModeX, this.BorderWrapModeY);
+        using Convolution2PassProcessor<TPixel> processor = new(this.Configuration, this.Kernel, false, this.Source, this.SourceRectangle, this.BorderWrapModeX, this.BorderWrapModeY);
 
         processor.Apply(source);
     }

--- a/tests/ImageSharp.Tests/Processing/Processors/Convolution/ConvolutionTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Convolution/ConvolutionTests.cs
@@ -7,6 +7,7 @@ using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
 
 namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution;
 
+[GroupOutput("Convolution")]
 public class ConvolutionTests
 {
     private static readonly ImageComparer ValidatorComparer = ImageComparer.TolerantPercentage(0.05F);

--- a/tests/ImageSharp.Tests/Processing/Processors/Convolution/ConvolutionTests.cs
+++ b/tests/ImageSharp.Tests/Processing/Processors/Convolution/ConvolutionTests.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Six Labors.
+// Licensed under the Six Labors Split License.
+
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing.Extensions.Convolution;
+using SixLabors.ImageSharp.Tests.TestUtilities.ImageComparison;
+
+namespace SixLabors.ImageSharp.Tests.Processing.Processors.Convolution;
+
+public class ConvolutionTests
+{
+    private static readonly ImageComparer ValidatorComparer = ImageComparer.TolerantPercentage(0.05F);
+
+    public static readonly TheoryData<DenseMatrix<float>> Values = new TheoryData<DenseMatrix<float>>
+    {
+        // Sharpening kernel.
+        new float[,]
+        {
+            { -1, -1, -1 },
+            { -1, 16, -1 },
+            { -1, -1, -1 }
+        }
+    };
+
+    public static readonly string[] InputImages =
+    [
+        TestImages.Bmp.Car,
+        TestImages.Png.CalliphoraPartial,
+        TestImages.Png.Blur
+    ];
+
+    [Theory]
+    [WithFileCollection(nameof(InputImages), nameof(Values), PixelTypes.Rgba32)]
+    public void OnFullImage<TPixel>(TestImageProvider<TPixel> provider, DenseMatrix<float> value)
+        where TPixel : unmanaged, IPixel<TPixel>
+        => provider.RunValidatingProcessorTest(
+            x => x.Convolve(value),
+            string.Join('_', value.Data),
+            ValidatorComparer);
+
+    [Theory]
+    [WithFileCollection(nameof(InputImages), nameof(Values), PixelTypes.Rgba32)]
+    public void InBox<TPixel>(TestImageProvider<TPixel> provider, DenseMatrix<float> value)
+        where TPixel : unmanaged, IPixel<TPixel>
+        => provider.RunRectangleConstrainedValidatingProcessorTest(
+            (x, rect) => x.Convolve(rect, value),
+            string.Join('_', value.Data),
+            ValidatorComparer);
+}

--- a/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/InBox_Rgba32_CalliphoraPartial_-1_-1_-1_-1_16_-1_-1_-1_-1.png
+++ b/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/InBox_Rgba32_CalliphoraPartial_-1_-1_-1_-1_16_-1_-1_-1_-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b311f117167e17b4611d525aef57146a6757db08f2a36fa093f45f237df9e1a2
+size 326809

--- a/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/InBox_Rgba32_Car_-1_-1_-1_-1_16_-1_-1_-1_-1.png
+++ b/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/InBox_Rgba32_Car_-1_-1_-1_-1_16_-1_-1_-1_-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0eabd5f7dd2f258d04d3f1db8ee4d958754541e0009ae183d6e512f408e3201
+size 249497

--- a/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/InBox_Rgba32_blur_-1_-1_-1_-1_16_-1_-1_-1_-1.png
+++ b/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/InBox_Rgba32_blur_-1_-1_-1_-1_16_-1_-1_-1_-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:048b4a1679852d34d6f74f01b750461ec9db2d3e7e3aa3d2d89d48e5725aa560
+size 142367

--- a/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/OnFullImage_Rgba32_CalliphoraPartial_-1_-1_-1_-1_16_-1_-1_-1_-1.png
+++ b/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/OnFullImage_Rgba32_CalliphoraPartial_-1_-1_-1_-1_16_-1_-1_-1_-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6f63d117433a93e30b9b41f68f676bb53eb1761f3c665f178ef07ec2c9626c3
+size 338527

--- a/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/OnFullImage_Rgba32_Car_-1_-1_-1_-1_16_-1_-1_-1_-1.png
+++ b/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/OnFullImage_Rgba32_Car_-1_-1_-1_-1_16_-1_-1_-1_-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d72a3994fc6dcc461da3af5176d5bf62c95b7abeffcbf5547172377db3b0d9ac
+size 287158

--- a/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/OnFullImage_Rgba32_blur_-1_-1_-1_-1_16_-1_-1_-1_-1.png
+++ b/tests/Images/External/ReferenceOutput/Convolution/ConvolutionTests/OnFullImage_Rgba32_blur_-1_-1_-1_-1_16_-1_-1_-1_-1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3fd7906f11e87a2b0043cde179317f53e9a2bf02d9e64763be8f9923d60f057
+size 257492


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/SixLabors/ImageSharp/pulls) open
- [x] I have verified that I am following the existing coding patterns and practice as demonstrated in the repository. These follow strict Stylecop rules :cop:.
- [x] I have provided test coverage for my change (where applicable)

### Description
<!-- A description of the changes proposed in the pull-request -->
See the roadmap discussion at https://github.com/SixLabors/ImageSharp/discussions/2533

Adds a general convolution API that accepts a `DenseMatrix<float>` to describe the convolution kernel. 

All this stuff has been the plumbing for various processors over the years and should be exposed publicly now it's solid. 

<!-- Thanks for contributing to ImageSharp! -->


<!-- greptile_comment -->

## Greptile Summary

This PR exposes a new public convolution API in ImageSharp, allowing users to apply custom convolution kernels to images while maintaining the library's existing performance optimizations and border handling capabilities.

Key changes:
- Added new `ConvolutionExtensions.cs` exposing public methods to apply custom convolution kernels using `DenseMatrix<float>`
- Added border wrapping mode support to control how pixels outside image bounds are handled during convolution
- Optimized implementation using two-pass approach for linearly separable kernels
- Updated processors to consistently handle border wrapping modes and alpha channel preservation
- Added basic test coverage for convolution operations using sharpening kernel

The changes look well-structured and maintain ImageSharp's existing patterns, though test coverage could be expanded to verify edge cases and different border handling modes.

<!-- /greptile_comment -->